### PR TITLE
Use a generic Button component

### DIFF
--- a/src/src/components/ActuatorModule.tsx
+++ b/src/src/components/ActuatorModule.tsx
@@ -2,19 +2,10 @@ import React, { useCallback,useContext } from 'react';
 import Switch from './common/switch/Switch';
 import { GeneralContext } from "../context/generalContext";
 import Button from './common/button/Button';
-import { withStyles } from '@material-ui/core/styles';
 import { useROSService } from '../hooks/useROSService'
 import ROSLIB from "roslib";
 
 const ActuatorModule = () => {
-
-    const ButtonStyle = withStyles({
-        contained: {
-            backgroundColor: 'lightgrey',
-            border: '2px solid rgba(0, 0, 0, 1.0)'
-        },
-
-    })(Button);
 
     // Reponse en retour a l appel du service
     const actuactorServiceCallback = useCallback(

--- a/src/src/components/ActuatorModule.tsx
+++ b/src/src/components/ActuatorModule.tsx
@@ -1,80 +1,86 @@
-import React, { useCallback,useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 import Switch from './common/switch/Switch';
-import { GeneralContext } from "../context/generalContext";
-import { Button } from '@material-ui/core';
+import { GeneralContext } from '../context/generalContext';
+import Button from './common/button/Button';
 import { withStyles } from '@material-ui/core/styles';
-import { useROSService } from '../hooks/useROSService'
-import ROSLIB from "roslib";
+import { useROSService } from '../hooks/useROSService';
+import ROSLIB from 'roslib';
 
 const ActuatorModule = () => {
+  // Reponse en retour a l appel du service
+  const actuactorServiceCallback = useCallback((x: any) => {}, []);
 
-    const ButtonStyle = withStyles({
-        contained: {
-            backgroundColor: 'lightgrey',
-            border: '2px solid rgba(0, 0, 0, 1.0)'
-        },
+  const context = useContext(GeneralContext);
+  const actuactorServiceCall = useROSService<any>(
+    actuactorServiceCallback,
+    '/provider_actuators/do_action_srv',
+    'sonia_common/ActuatorDoActionSrv'
+  );
 
-    })(Button);
+  // FORMATAGE DU MESSAGE A ENVOYER AU SERVICE A VERIFIER
+  const HandleChangeSwitch = (value: any) => {
+    context.setIsRoboticArmClosed(!context.isRoboticArmClosed);
+    var request = new ROSLIB.ServiceRequest({
+      ELEMENT_ARM: 2,
+      ARM_OPEN: !value,
+      ACTION_ARM_EXEC: 1,
+    });
+    actuactorServiceCall(request);
+  };
 
-    // Reponse en retour a l appel du service
-    const actuactorServiceCallback = useCallback(
-        (x: any) => {
-        }, []
-    )
+  // FORMATAGE DU MESSAGE A ENVOYER AU SERVICE A VERIFIER
+  const handleChangeButtonTorpedo = () => {
+    var request = new ROSLIB.ServiceRequest({
+      ELEMENT_TORPEDO: 0,
+      SIDE_PORT: 0,
+      ACTION_DROPPER_LAUCH: 1,
+    });
+    actuactorServiceCall(request);
+  };
 
-    const context = useContext(GeneralContext)
-    const actuactorServiceCall = useROSService<any>(actuactorServiceCallback, "/provider_actuators/do_action_srv", "sonia_common/ActuatorDoActionSrv")
+  // FORMATAGE DU MESSAGE A ENVOYER AU SERVICE A VERIFIER
+  const handleChangeButtonDropObject = () => {
+    var request = new ROSLIB.ServiceRequest({
+      ELEMENT_TORPEDO: 1,
+      SIDE_PORT: 0,
+      ACTION_DROPPER_LAUCH: 1,
+    });
+    actuactorServiceCall(request);
+  };
 
-    // FORMATAGE DU MESSAGE A ENVOYER AU SERVICE A VERIFIER
-    const HandleChangeSwitch = (value: any) => {
-
-        context.setIsRoboticArmClosed(!context.isRoboticArmClosed)
-        var request = new ROSLIB.ServiceRequest({
-            ELEMENT_ARM: 2,
-            ARM_OPEN: !value,
-            ACTION_ARM_EXEC: 1
-        });
-        actuactorServiceCall(request)
-    } 
-
-    // FORMATAGE DU MESSAGE A ENVOYER AU SERVICE A VERIFIER
-    const handleChangeButtonTorpedo = () => {
-        var request = new ROSLIB.ServiceRequest({
-            ELEMENT_TORPEDO: 0,
-            SIDE_PORT: 0,
-            ACTION_DROPPER_LAUCH: 1
-        });
-        actuactorServiceCall(request)
-    }
-
-    // FORMATAGE DU MESSAGE A ENVOYER AU SERVICE A VERIFIER
-    const handleChangeButtonDropObject = () => {
-        var request = new ROSLIB.ServiceRequest({
-            ELEMENT_TORPEDO: 1,
-            SIDE_PORT: 0,
-            ACTION_DROPPER_LAUCH: 1
-        });
-        actuactorServiceCall(request)
-    }
-
-    return (
-        <GeneralContext.Consumer>
-            {context => context && (
-                <div style={{ width: '100%', height: '100%', flexDirection: 'row', textAlign: 'center' }}>
-                    <h1 style={{ fontSize: '20px', textAlign: 'center' }}>ROBOTIC ARM</h1>
-                    <Switch onLabel="Open"
-                        offLabel="Closed"
-                        vertical={false}
-                        value={!context.isRoboticArmClosed}
-                        handler={HandleChangeSwitch} />
-                    <h1 style={{ fontSize: '20px', textAlign: 'center' }}>TORPEDO</h1>
-                    <ButtonStyle variant='contained' style={{ fontSize: '20px', alignSelf: 'center' }} onClick={handleChangeButtonTorpedo}>LAUNCH</ButtonStyle>
-                    <h1 style={{ fontSize: '20px', textAlign: 'center' }}>DROP OBJECT</h1>
-                    <ButtonStyle variant='contained' style={{ fontSize: '20px', alignSelf: 'center' }} onClick={handleChangeButtonDropObject}>DROP</ButtonStyle>
-                </div>
-            )}
-        </GeneralContext.Consumer>
-    );
+  return (
+    <GeneralContext.Consumer>
+      {(context) =>
+        context && (
+          <div
+            style={{
+              width: '100%',
+              height: '100%',
+              flexDirection: 'row',
+              textAlign: 'center',
+            }}
+          >
+            <h1 style={{ fontSize: '20px', textAlign: 'center' }}>
+              ROBOTIC ARM
+            </h1>
+            <Switch
+              onLabel="Open"
+              offLabel="Closed"
+              vertical={false}
+              value={!context.isRoboticArmClosed}
+              handler={HandleChangeSwitch}
+            />
+            <h1 style={{ fontSize: '20px', textAlign: 'center' }}>TORPEDO</h1>
+            <Button handler={handleChangeButtonTorpedo} label="Launch" />
+            <h1 style={{ fontSize: '20px', textAlign: 'center' }}>
+              DROP OBJECT
+            </h1>
+            <Button handler={handleChangeButtonDropObject} label="Drop" />
+          </div>
+        )
+      }
+    </GeneralContext.Consumer>
+  );
 };
 
 export default ActuatorModule;

--- a/src/src/components/ActuatorModule.tsx
+++ b/src/src/components/ActuatorModule.tsx
@@ -17,6 +17,7 @@ const ActuatorModule = () => {
     'sonia_common/ActuatorDoActionSrv'
   );
 
+
   // FORMATAGE DU MESSAGE A ENVOYER AU SERVICE A VERIFIER
   const HandleChangeSwitch = (value: any) => {
     context.setIsRoboticArmClosed(!context.isRoboticArmClosed);

--- a/src/src/components/ImageViewer.tsx
+++ b/src/src/components/ImageViewer.tsx
@@ -1,201 +1,203 @@
 import React, { useCallback, useContext, useState, useRef } from 'react';
-import { GeneralContext } from "../context/generalContext";
+import { GeneralContext } from '../context/generalContext';
 import { makeStyles } from '@material-ui/core/styles';
 import Select from '@material-ui/core/Select';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
-import ROSLIB from "roslib";
+import ROSLIB from 'roslib';
 import PlayCircleFilledIcon from '@material-ui/icons/PlayCircleFilled';
 import StopIcon from '@material-ui/icons/Stop';
-import Button from '@material-ui/core/Button';
+import Button from './common/button/Button';
 import CachedIcon from '@material-ui/icons/Cached';
-import { RosContext } from "../context/rosContext";
-import { useROSService } from '../hooks/useROSService'
-import jpeg from 'jpeg-js'
+import { RosContext } from '../context/rosContext';
+import { useROSService } from '../hooks/useROSService';
+import jpeg from 'jpeg-js';
 
 const ImageViewer = () => {
-
-    // Function to convert uncompressed data rgb8 to compressed base 64 jpeg
-    function rgb8ImageToBase64Jpeg(msg: any) {
-        var raw = atob(msg.data)
-        var array = new Uint8Array(new ArrayBuffer(raw.length))
-        for (let i = 0; i < raw.length; i++) {
-            array[i] = raw.charCodeAt(i)
-        }
-
-        var frameData = Buffer.alloc(msg.width * msg.height * 4)
-        for (let i = 0; i < msg.width * msg.height; i++) {
-            frameData[4 * i + 0] = array[3 * i + 0]
-            frameData[4 * i + 1] = array[3 * i + 1]
-            frameData[4 * i + 2] = array[3 * i + 2]
-            frameData[4 * i + 3] = 0
-        }
-        var rawImageData = {
-            data: frameData,
-            width: msg.width,
-            height: msg.height
-        }
-        return jpeg.encode(rawImageData, 50).data.toString('base64')
+  // Function to convert uncompressed data rgb8 to compressed base 64 jpeg
+  function rgb8ImageToBase64Jpeg(msg: any) {
+    var raw = atob(msg.data);
+    var array = new Uint8Array(new ArrayBuffer(raw.length));
+    for (let i = 0; i < raw.length; i++) {
+      array[i] = raw.charCodeAt(i);
     }
 
-    const ros = useContext(RosContext);
-
-    const useStyles = makeStyles((theme) => ({
-        formControl: {
-            margin: theme.spacing(1),
-            minWidth: 120,
-        },
-        selectEmpty: {
-            marginTop: theme.spacing(2),
-        },
-        button: {
-            margin: theme.spacing(1),
-            "& .MuiButton-iconSizeMedium > *:first-child": {
-                fontSize: "20px"
-            },
-            "& .MuiButton-startIcon": {
-                marginLeft: "-2px",
-                marginRight: "0px"
-            }
-        },
-    }));
-
-    const [topic, setTopic] = useState<ROSLIB.Topic | null>(null);
-    const [listTopic, setListTopic] = useState<[]>([]);
-    const topicRef = useRef<ROSLIB.Topic | null>(null);
-    const [image, setImage] = useState('')
-
-    const imageCallback = useCallback(
-        (x: any) => {
-
-            var im: any;
-            if (x.encoding == "bgr8" || x.encoding == "rgb8")
-                im = "data:image/jpeg;base64," + rgb8ImageToBase64Jpeg(x);
-            else if (x.format.includes("jpeg"))
-                im = "data:image/jpeg;base64," + x.data;
-            else
-            {
-                window.alert("Video format (" + x.encoding + ") is not supported, make sure you have the right encoding type or add it to the list");
-                if (topicRef.current) {
-                    topicRef.current.unsubscribe()
-                    setTopic(null)
-                }
-            }
-            setImage(im)
-        },
-        []
-    )
-
-    const handleChange = (x: any) => {
-        if (topic) {
-            topic.unsubscribe()
-        }
-        if (x.target.value != "None") {
-            listTopic.map((value, index) => {
-                if (value["value"] == x.target.value) {
-                    const type = value["type"]
-                    const newtopic = new ROSLIB.Topic({ ros: ros, name: x.target.value, messageType: type })
-                    setTopic(newtopic)
-                    topicRef.current = newtopic;
-                    if (newtopic) {
-                        newtopic.subscribe(imageCallback);
-                    }
-                }
-            })
-        }
+    var frameData = Buffer.alloc(msg.width * msg.height * 4);
+    for (let i = 0; i < msg.width * msg.height; i++) {
+      frameData[4 * i + 0] = array[3 * i + 0];
+      frameData[4 * i + 1] = array[3 * i + 1];
+      frameData[4 * i + 2] = array[3 * i + 2];
+      frameData[4 * i + 3] = 0;
     }
+    var rawImageData = {
+      data: frameData,
+      width: msg.width,
+      height: msg.height,
+    };
+    return jpeg.encode(rawImageData, 50).data.toString('base64');
+  }
 
-    const clickStop = () => {
-        if (topic) {
-            topic.unsubscribe()
+  const ros = useContext(RosContext);
+
+  const useStyles = makeStyles((theme) => ({
+    formControl: {
+      margin: theme.spacing(1),
+      minWidth: 120,
+    },
+    selectEmpty: {
+      marginTop: theme.spacing(2),
+    },
+    button: {
+      margin: theme.spacing(1),
+      '& .MuiButton-iconSizeMedium > *:first-child': {
+        fontSize: '20px',
+      },
+      '& .MuiButton-startIcon': {
+        marginLeft: '-2px',
+        marginRight: '0px',
+      },
+    },
+  }));
+
+  const [topic, setTopic] = useState<ROSLIB.Topic | null>(null);
+  const [listTopic, setListTopic] = useState<[]>([]);
+  const topicRef = useRef<ROSLIB.Topic | null>(null);
+  const [image, setImage] = useState('');
+
+  const imageCallback = useCallback((x: any) => {
+    var im: any;
+    if (x.encoding == 'bgr8' || x.encoding == 'rgb8')
+      im = 'data:image/jpeg;base64,' + rgb8ImageToBase64Jpeg(x);
+    else if (x.format.includes('jpeg')) im = 'data:image/jpeg;base64,' + x.data;
+    else {
+      window.alert(
+        'Video format (' +
+          x.encoding +
+          ') is not supported, make sure you have the right encoding type or add it to the list'
+      );
+      if (topicRef.current) {
+        topicRef.current.unsubscribe();
+        setTopic(null);
+      }
+    }
+    setImage(im);
+  }, []);
+
+  const handleChange = (x: any) => {
+    if (topic) {
+      topic.unsubscribe();
+    }
+    if (x.target.value != 'None') {
+      listTopic.map((value, index) => {
+        if (value['value'] == x.target.value) {
+          const type = value['type'];
+          const newtopic = new ROSLIB.Topic({
+            ros: ros,
+            name: x.target.value,
+            messageType: type,
+          });
+          setTopic(newtopic);
+          topicRef.current = newtopic;
+          if (newtopic) {
+            newtopic.subscribe(imageCallback);
+          }
         }
+      });
     }
+  };
 
-    const clickPlay = () => {
-        if (topic) {
-            topic.subscribe(imageCallback);
-        }
+  const clickStop = () => {
+    if (topic) {
+      topic.unsubscribe();
     }
+  };
 
-    //Filtre sur les types de message que le souhaite 
-    const messageFilter = ["sensor_msgs/CompressedImage", "sensor_msgs/Image"]
-
-    const serviceCallback = useCallback(
-        (x: any) => {
-            var tab: any = []
-            x.topics.map((value: any, index: any) => {
-                if (messageFilter.includes(x.types[index])) {
-                    const obj = { value: value, type: x.types[index] }
-                    tab.push(obj);
-                }
-            })
-            setListTopic(tab)
-        }, []
-    )
-
-    const topicServiceCall = useROSService<any>(serviceCallback, "/rosapi/topics/", "rosapi/Topics")
-
-    const clickUpdate = () => {
-        var request = new ROSLIB.ServiceRequest({});
-        topicServiceCall(request)
+  const clickPlay = () => {
+    if (topic) {
+      topic.subscribe(imageCallback);
     }
+  };
 
-    const classes = useStyles();
+  //Filtre sur les types de message que le souhaite
+  const messageFilter = ['sensor_msgs/CompressedImage', 'sensor_msgs/Image'];
 
-    return (
-        <GeneralContext.Consumer>
-            {context => context && (
-                <div style={{ width: '100%', height: '100%' }}>
-                    <div style={{ width: '96%', height: '90%', flexDirection: 'row', marginLeft: '2%' }}>
-                        <h1 style={{ fontSize: '20px', textAlign: 'center' }}>CAMERA VIEWER</h1>
-                        <FormControl variant="filled" className={classes.formControl}>
-                            <InputLabel id="select-outlined-label">Topic</InputLabel>
-                            <Select
-                                labelId="select-outlined-label"
-                                id="select-outlined"
-                                onChange={handleChange}
-                                label="Topic"
-                                value={topic?.name ? topic.name : "None"}
-                            >
-                                <MenuItem value={"None"}>None</MenuItem>
-                                {listTopic.map((value, index) => {
-                                    return <MenuItem value={value["value"]}>{value["value"]}</MenuItem>
-                                })}
-                            </Select>
-                        </FormControl>
-                        <Button
-                            variant="contained"
-                            color="default"
-                            className={classes.button}
-                            startIcon={<CachedIcon />}
-                            onClick={clickUpdate}
-                        ></Button>
-                        <br></br>
-                        <Button
-                            variant="contained"
-                            color="default"
-                            className={classes.button}
-                            startIcon={<StopIcon />}
-                            onClick={clickStop}
-                        ></Button>
-                        <Button
-                            variant="contained"
-                            color="default"
-                            className={classes.button}
-                            startIcon={<PlayCircleFilledIcon />}
-                            onClick={clickPlay}
-                        ></Button>
-                        <div style={{ width: "100%", height: "calc(100% - 140px)" }}>
-                        {image !== '' ?
-                            <img src={image} width="100%" height="100%"></img> : <img width="100%" height="100%"></img>
-                        }
-                        </div>
-                    </div>
-                </div>
-            )}
-        </GeneralContext.Consumer>
-    );
+  const serviceCallback = useCallback((x: any) => {
+    var tab: any = [];
+    x.topics.map((value: any, index: any) => {
+      if (messageFilter.includes(x.types[index])) {
+        const obj = { value: value, type: x.types[index] };
+        tab.push(obj);
+      }
+    });
+    setListTopic(tab);
+  }, []);
+
+  const topicServiceCall = useROSService<any>(
+    serviceCallback,
+    '/rosapi/topics/',
+    'rosapi/Topics'
+  );
+
+  const clickUpdate = () => {
+    var request = new ROSLIB.ServiceRequest({});
+    topicServiceCall(request);
+  };
+
+  const classes = useStyles();
+
+  return (
+    <GeneralContext.Consumer>
+      {(context) =>
+        context && (
+          <div style={{ width: '100%', height: '100%' }}>
+            <div
+              style={{
+                width: '96%',
+                height: '90%',
+                flexDirection: 'row',
+                marginLeft: '2%',
+              }}
+            >
+              <h1 style={{ fontSize: '20px', textAlign: 'center' }}>
+                CAMERA VIEWER
+              </h1>
+              <FormControl variant="filled" className={classes.formControl}>
+                <InputLabel id="select-outlined-label">Topic</InputLabel>
+                <Select
+                  labelId="select-outlined-label"
+                  id="select-outlined"
+                  onChange={handleChange}
+                  label="Topic"
+                  value={topic?.name ? topic.name : 'None'}
+                >
+                  <MenuItem value={'None'}>None</MenuItem>
+                  {listTopic.map((value, index) => {
+                    return (
+                      <MenuItem value={value['value']}>
+                        {value['value']}
+                      </MenuItem>
+                    );
+                  })}
+                </Select>
+              </FormControl>
+              <Button label={<CachedIcon />} handler={clickUpdate} />
+              <br></br>
+              <Button label={<StopIcon />} handler={clickStop} />
+              <Button label={<PlayCircleFilledIcon />} handler={clickPlay} />
+              <div style={{ width: '100%', height: 'calc(100% - 140px)' }}>
+                {image !== '' ? (
+                  <img src={image} width="100%" height="100%"></img>
+                ) : (
+                  <img width="100%" height="100%"></img>
+                )}
+              </div>
+            </div>
+          </div>
+        )
+      }
+    </GeneralContext.Consumer>
+  );
 };
 
 export default ImageViewer;

--- a/src/src/components/ImageViewer.tsx
+++ b/src/src/components/ImageViewer.tsx
@@ -166,18 +166,18 @@ const ImageViewer = () => {
                             </Select>
                         </FormControl>
                         <Button
-                            // className={classes.button}
+                            className={classes.button}
                             label={<CachedIcon />}
                             handler={clickUpdate}
                         ></Button>
                         <br></br>
                         <Button
-                            // className={classes.button}
+                            className={classes.button}
                             label={<StopIcon />}
                             handler={clickStop}
                         ></Button>
                         <Button
-                            // className={classes.button}
+                            className={classes.button}
                             label={<PlayCircleFilledIcon />}
                             handler={clickPlay}
                         ></Button>

--- a/src/src/components/MenuModule.tsx
+++ b/src/src/components/MenuModule.tsx
@@ -1,46 +1,43 @@
 import React from 'react';
-import Button from '@material-ui/core/Button';
+import Button from './common/button/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import MenuIcon from '@material-ui/icons/Menu';
 
-const MenuModule = (props:any) => {
-    const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+const MenuModule = (props: any) => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
-    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-        setAnchorEl(event.currentTarget);
-    };
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
 
-    const handleClose = () => {
-        setAnchorEl(null);
-    };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
 
-    const handleClearLayout = () => {
-        localStorage.clear()
-        window.location.reload()
-    }
+  const handleClearLayout = () => {
+    localStorage.clear();
+    window.location.reload();
+  };
 
-    return (
-        <div>
-            <Button onClick={handleClick}>
-                <MenuIcon/>
-            </Button>
-            <Menu
-                id="simple-menu"
-                anchorEl={anchorEl}
-                keepMounted
-                open={Boolean(anchorEl)}
-                onClose={handleClose}
-            >
-                <MenuItem onClick={handleClose}>File</MenuItem>
-                <MenuItem onClick={handleClose}>Plugins</MenuItem>
-                <MenuItem onClick={handleClose}>Running</MenuItem>
-                <MenuItem onClick={handleClearLayout}>Clear layout</MenuItem>
-                <MenuItem onClick={handleClose}>Help</MenuItem>
+  return (
+    <div>
+      <Button label={<MenuIcon />} handler={handleClick} />
+      <Menu
+        id="simple-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem onClick={handleClose}>File</MenuItem>
+        <MenuItem onClick={handleClose}>Plugins</MenuItem>
+        <MenuItem onClick={handleClose}>Running</MenuItem>
+        <MenuItem onClick={handleClearLayout}>Clear layout</MenuItem>
+        <MenuItem onClick={handleClose}>Help</MenuItem>
+      </Menu>
+    </div>
+  );
+};
 
-            </Menu>
-        </div>
-    );
-}
-
-export default MenuModule
+export default MenuModule;

--- a/src/src/components/TestBoardModule.tsx
+++ b/src/src/components/TestBoardModule.tsx
@@ -1,116 +1,122 @@
 import React from 'react';
-import Button from '@material-ui/core/Button';
+import Button from './common/button/Button';
 import TextField from '@material-ui/core/TextField';
-import Checkbox from '@material-ui/core/Checkbox'
-import {withStyles} from "@material-ui/core/styles";
-import {useROSTopicPublisher} from "../hooks/useROSTopicPublisher";
+import Checkbox from '@material-ui/core/Checkbox';
+import { withStyles } from '@material-ui/core/styles';
+import { useROSTopicPublisher } from '../hooks/useROSTopicPublisher';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-
 const TestBoardModule = () => {
+  const ButtonStyle = withStyles({
+    contained: {
+      backgroundColor: 'lightgrey',
+      border: '2px solid rgba(0, 0, 0, 1.0)',
+    },
+  })(Button);
 
-    const ButtonStyle = withStyles({
-        contained: {
-            backgroundColor: 'lightgrey',
-            border: '2px solid rgba(0, 0, 0, 1.0)'
-        },
+  const [slave, setSlave] = React.useState('');
+  const [cmd, setCmd] = React.useState('');
+  const [data, setData] = React.useState('');
+  const [rate, setRate] = React.useState('');
+  const [isSingleSend, setIsSingleSend] = React.useState(true);
+  let intervalVar: any;
+  const testBoardPublisher = useROSTopicPublisher<any>(
+    '/interface_rs485/dataRx',
+    'sonia_common/SendRS485Msg'
+  );
 
-    })(Button);
-
-    const [slave, setSlave] = React.useState("")
-    const [cmd, setCmd] = React.useState("")
-    const [data, setData] = React.useState("")
-    const [rate, setRate] = React.useState("")
-    const [isSingleSend, setIsSingleSend] = React.useState(true)
-    let intervalVar: any
-    const testBoardPublisher = useROSTopicPublisher<any>("/interface_rs485/dataRx", "sonia_common/SendRS485Msg")
-
-    const handleStart = () => {
-        let toPublish = {
-            slave: slave,
-            cmd: cmd,
-            data: data
-        }
-        if(!isSingleSend){
-            console.log("Continuous publishing...")
-            intervalVar = setInterval(function () {
-                testBoardPublisher(toPublish)
-          }, parseInt(rate))
-
-        }
-        else {
-            testBoardPublisher(toPublish)
-        }
+  const handleStart = () => {
+    let toPublish = {
+      slave: slave,
+      cmd: cmd,
+      data: data,
+    };
+    if (!isSingleSend) {
+      console.log('Continuous publishing...');
+      intervalVar = setInterval(function () {
+        testBoardPublisher(toPublish);
+      }, parseInt(rate));
+    } else {
+      testBoardPublisher(toPublish);
     }
-    const handleStop = () => {
-        console.log("Continuous publishing stopped...")
-        clearInterval(intervalVar)
-    }
-    const handleSingleCheck = () => {
-        setIsSingleSend(!isSingleSend)
-    }
-    return (
+  };
+  const handleStop = () => {
+    console.log('Continuous publishing stopped...');
+    clearInterval(intervalVar);
+  };
+  const handleSingleCheck = () => {
+    setIsSingleSend(!isSingleSend);
+  };
+  return (
+    <div>
+      <h1>Test board</h1>
+      <form>
         <div>
-            <h1>Test board</h1>
-            <form>
-                <div>
-                    <TextField id="outlined-basic"
-                               label="Slave"
-                               variant="outlined"
-                               name="slave"
-                               type="number"
-                               value={slave}
-                               style={{margin: '5px'}}
-                               onChange={(event)=>setSlave(event.target.value)}/>
-                </div>
-                <div>
-                    <TextField id="outlined-basic"
-                               label="Cmd"
-                               variant="outlined"
-                               name="cmd"
-                               value={cmd}
-                               style={{margin: '5px'}}
-                               onChange={(event)=>setCmd(event.target.value)} />
-                </div>
-                <div>
-                    <TextField id="outlined-basic"
-                               label="Data"
-                               variant="outlined"
-                               name="data"
-                               style={{margin: '5px'}}
-                               value={data}
-                               onChange={(event)=>setData(event.target.value)} />
-                </div>
-                <div>
-                    <TextField id="outlined-basic"
-                               label="Rate"
-                               variant="outlined"
-                               name="rate"
-                               value={rate}
-                               type="number"
-                               style={{margin: '5px'}}
-                               onChange={(event)=>setRate(event.target.value)} />
-                </div>
-                <div style={{margin: "5px"}}>
-                    <FormControlLabel
-                        control={<Checkbox checked={isSingleSend} onChange={handleSingleCheck} name="checkedA" />}
-                        label="Single send"
-                    />
-                </div>
-                <div style={{margin: "5px"}}>
-                    <ButtonStyle variant='contained' style={{ fontSize: '20px', alignSelf: 'center' }}
-                                 onClick={handleStart}>
-                        Start
-                    </ButtonStyle>
-                </div>
-                <div style={{margin: "5px"}}>
-                    <ButtonStyle variant='contained' style={{ fontSize: '20px', alignSelf: 'center' }}
-                                 onClick={handleStop}>
-                        Stop
-                    </ButtonStyle>
-                </div>
-            </form>
+          <TextField
+            id="outlined-basic"
+            label="Slave"
+            variant="outlined"
+            name="slave"
+            type="number"
+            value={slave}
+            style={{ margin: '5px' }}
+            onChange={(event) => setSlave(event.target.value)}
+          />
         </div>
-    )
-}
-export default TestBoardModule
+        <div>
+          <TextField
+            id="outlined-basic"
+            label="Cmd"
+            variant="outlined"
+            name="cmd"
+            value={cmd}
+            style={{ margin: '5px' }}
+            onChange={(event) => setCmd(event.target.value)}
+          />
+        </div>
+        <div>
+          <TextField
+            id="outlined-basic"
+            label="Data"
+            variant="outlined"
+            name="data"
+            style={{ margin: '5px' }}
+            value={data}
+            onChange={(event) => setData(event.target.value)}
+          />
+        </div>
+        <div>
+          <TextField
+            id="outlined-basic"
+            label="Rate"
+            variant="outlined"
+            name="rate"
+            value={rate}
+            type="number"
+            style={{ margin: '5px' }}
+            onChange={(event) => setRate(event.target.value)}
+          />
+        </div>
+        <div style={{ margin: '5px' }}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={isSingleSend}
+                onChange={handleSingleCheck}
+                name="checkedA"
+              />
+            }
+            label="Single send"
+          />
+        </div>
+        <div style={{ margin: '5px' }}>
+          <Button label="Start" handler={handleStart} />
+        </div>
+        <div style={{ margin: '5px' }}>
+          <Button label="Stop" handler={handleStop} />
+        </div>
+      </form>
+    </div>
+  );
+};
+export default TestBoardModule;

--- a/src/src/components/ToolbarModule.tsx
+++ b/src/src/components/ToolbarModule.tsx
@@ -1,247 +1,264 @@
-import React, {useCallback, useState} from 'react';
-import AppBar from '@material-ui/core/AppBar'
-import Toolbar from "@material-ui/core/Toolbar"
-import Button from "@material-ui/core/Button"
-import MenuModule from "./MenuModule"
+import React, { useCallback, useState } from 'react';
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import Button from './common/button/Button';
+import MenuModule from './MenuModule';
 import IconButton from '@material-ui/core/IconButton';
-import { useROSService } from '../hooks/useROSService'
-import BatterieLevelIndicator from "./BatteryLevelIndicatorModule";
-import ROSLIB from "roslib";
-import LabelAndValueModule from "./LabelAndValueModule";
-import {useROSTopicSubscriber} from "../hooks/useROSTopicSubscriber";
+import { useROSService } from '../hooks/useROSService';
+import BatterieLevelIndicator from './BatteryLevelIndicatorModule';
+import ROSLIB from 'roslib';
+import LabelAndValueModule from './LabelAndValueModule';
+import { useROSTopicSubscriber } from '../hooks/useROSTopicSubscriber';
 
 const ToolbarModule = () => {
+  /**
+   * TODO
+   * Verifier la conformité format des messages ROS
+   *
+   */
 
-    /**
-     * TODO
-     * Verifier la conformité format des messages ROS
-     *
-     */
+  const [isMissionSwitchOn, setIsMissionSwitchOn] = React.useState(false);
+  const [isKillSwitchOn, setIsKillSwitchOn] = React.useState(false);
+  const [AUV7Temp, setAUV7Temp] = React.useState(0);
+  const [AUV8Temp, setAUV8Temp] = React.useState(0);
 
-    const [isMissionSwitchOn, setIsMissionSwitchOn] = React.useState(false)
-    const [isKillSwitchOn, setIsKillSwitchOn] = React.useState(false);
-    const [AUV7Temp, setAUV7Temp] = React.useState(0)
-    const [AUV8Temp, setAUV8Temp] = React.useState(0)
+  const [batteryLevel1, setbatteryLevel1] = React.useState('0');
+  const [batteryLevel2, setbatteryLevel2] = React.useState('0');
 
-    const [batteryLevel1, setbatteryLevel1] = React.useState('0')
-    const [batteryLevel2, setbatteryLevel2] = React.useState('0')
+  const toolbarServiceCallback = useCallback((x: any) => {}, []);
 
+  const missionSwitchCallback = useCallback((x: any) => {
+    let switchState = x.state;
+    setIsMissionSwitchOn(switchState);
+  }, []);
 
-    const toolbarServiceCallback = useCallback(
-        (x: any) => {
-        }, []
-    )
+  const killSwitchCallback = useCallback((x: any) => {
+    let switchState = x.state;
+    setIsKillSwitchOn(switchState);
+  }, []);
 
-    const missionSwitchCallback = useCallback(
-        (x: any) => {
-            let switchState = x.state
-            setIsMissionSwitchOn(switchState)
-        }, []
-    )
+  const batteryLevelCallback = useCallback((x: any) => {
+    let data = parseFloat(x.data).toFixed(2);
+    if (x.slave === 1) setbatteryLevel1(data);
+    else if (x.slave === 3) setbatteryLevel2(data);
+  }, []);
 
-    const killSwitchCallback = useCallback(
-        (x: any) => {
-            let switchState = x.state
-            setIsKillSwitchOn(switchState)
-        }, []
-    )
+  const AUV7Callback = useCallback((x: any) => {
+    let data = x.data;
+    let parsed = JSON.parse(data);
+    setAUV7Temp(parsed);
+  }, []);
+  const AUV8Callback = useCallback((x: any) => {
+    let data = x.data;
+    let parsed = JSON.parse(data);
+    setAUV8Temp(parsed);
+  }, []);
 
-    const batteryLevelCallback = useCallback(
-        (x: any) => {
-            let data = parseFloat(x.data).toFixed(2)
-            if(x.slave === 1)
-                setbatteryLevel1(data)
-            else if(x.slave === 3)
-                setbatteryLevel2(data)
-        }, []
-    )
+  const toolbarServicesCall = useROSService<any>(
+    toolbarServiceCallback,
+    '/proc_control/EnableControl',
+    'sonia_common/EnableControl'
+  );
+  const startStopCameraCall = useROSService<any>(
+    toolbarServiceCallback,
+    '/provider_vision/StarStopCamera',
+    'sonia_common/StartStopMedia'
+  );
+  useROSTopicSubscriber<any>(
+    batteryLevelCallback,
+    '/provider_power/power',
+    'sonia_common/PowerMsg'
+  );
+  useROSTopicSubscriber<any>(
+    killSwitchCallback,
+    '/provider_kill_mission/kill_switch_msg',
+    'sonia_common/KillSwitchMsg'
+  );
+  useROSTopicSubscriber<any>(
+    missionSwitchCallback,
+    '/provider_kill_mission/mission_switch_msg',
+    'sonia_common/MissionSwitchMsg'
+  );
+  useROSTopicSubscriber<any>(
+    AUV7Callback,
+    '/provider_system/system_temperature',
+    'std_msgs/Float32'
+  );
+  useROSTopicSubscriber<any>(
+    AUV8Callback,
+    '/provider_jetson/system_temperature',
+    'std_msgs/Float32'
+  );
 
-    const AUV7Callback = useCallback(
-        (x: any) => {
-            let data = x.data
-            let parsed = JSON.parse(data)
-            setAUV7Temp(parsed)
-        }, []
-    )
-    const AUV8Callback = useCallback(
-        (x: any) => {
-            let data = x.data
-            let parsed = JSON.parse(data)
-            setAUV8Temp(parsed)
-        }, []
-    )
+  let handleAllAxisClicked = () => {
+    const request = new ROSLIB.ServiceRequest({
+      X: 1,
+      Y: 1,
+      Z: 1,
+      PITCH: 1,
+      ROLL: 1,
+      YAW: 1,
+    });
+    toolbarServicesCall(request);
+  };
 
-    const toolbarServicesCall = useROSService<any>(toolbarServiceCallback, "/proc_control/EnableControl", "sonia_common/EnableControl")
-    const startStopCameraCall = useROSService<any>(toolbarServiceCallback, "/provider_vision/StarStopCamera", "sonia_common/StartStopMedia")
-    useROSTopicSubscriber<any>(batteryLevelCallback, "/provider_power/power", "sonia_common/PowerMsg")
-    useROSTopicSubscriber<any>(killSwitchCallback, "/provider_kill_mission/kill_switch_msg", "sonia_common/KillSwitchMsg")
-    useROSTopicSubscriber<any>(missionSwitchCallback, "/provider_kill_mission/mission_switch_msg", "sonia_common/MissionSwitchMsg")
-    useROSTopicSubscriber<any>(AUV7Callback, "/provider_system/system_temperature", "std_msgs/Float32")
-    useROSTopicSubscriber<any>(AUV8Callback, "/provider_jetson/system_temperature", "std_msgs/Float32")
+  let handleXYAxisClicked = () => {
+    const request = new ROSLIB.ServiceRequest({
+      X: 1,
+      Y: 1,
+      Z: -1,
+      PITCH: -1,
+      ROLL: -1,
+      YAW: -1,
+    });
+    toolbarServicesCall(request);
+  };
 
-    let handleAllAxisClicked = () => {
-        const request = new ROSLIB.ServiceRequest({
-            X: 1,
-            Y:1,
-            Z: 1,
-            PITCH: 1,
-            ROLL: 1,
-            YAW: 1
-        });
-        toolbarServicesCall(request)
-    }
+  let handleDepthAxisClicked = () => {
+    const request = new ROSLIB.ServiceRequest({
+      X: -1,
+      Y: -1,
+      Z: 1,
+      PITCH: -1,
+      ROLL: -1,
+      YAW: -1,
+    });
+    toolbarServicesCall(request);
+  };
 
-    let handleXYAxisClicked = () => {
-        const request = new ROSLIB.ServiceRequest({
-            X: 1,
-            Y:1,
-            Z: -1,
-            PITCH: -1,
-            ROLL: -1,
-            YAW: -1
-        });
-        toolbarServicesCall(request)
-    }
+  let handleRollAxisClicked = () => {
+    const request = new ROSLIB.ServiceRequest({
+      X: -1,
+      Y: -1,
+      Z: -1,
+      PITCH: -1,
+      ROLL: 1,
+      YAW: -1,
+    });
+    toolbarServicesCall(request);
+  };
 
-    let handleDepthAxisClicked = () => {
-        const request = new ROSLIB.ServiceRequest({
-            X:- 1,
-            Y: -1,
-            Z: 1,
-            PITCH: -1,
-            ROLL: -1,
-            YAW: -1
-        });
-        toolbarServicesCall(request)
-    }
+  let handleYawAxisClicked = () => {
+    const request = new ROSLIB.ServiceRequest({
+      X: -1,
+      Y: -1,
+      Z: -1,
+      PITCH: -1,
+      ROLL: -1,
+      YAW: 1,
+    });
+    toolbarServicesCall(request);
+  };
 
-    let handleRollAxisClicked = () => {
-        const request = new ROSLIB.ServiceRequest({
-            X: -1,
-            Y: -1,
-            Z: -1,
-            PITCH: -1,
-            ROLL: 1,
-            YAW: -1
-        });
-        toolbarServicesCall(request)
-    }
+  let handlePitchAxisClicked = () => {
+    const request = new ROSLIB.ServiceRequest({
+      X: -1,
+      Y: -1,
+      Z: -1,
+      PITCH: 1,
+      ROLL: -1,
+      YAW: -1,
+    });
+    toolbarServicesCall(request);
+  };
 
-    let handleYawAxisClicked = () => {
-        const request = new ROSLIB.ServiceRequest({
-            X: -1,
-            Y: -1,
-            Z: -1,
-            PITCH: -1,
-            ROLL: -1,
-            YAW: 1
-        });
-        toolbarServicesCall(request)
-    }
+  let handleStartFrontCameraClicked = () => {
+    const request = new ROSLIB.ServiceRequest({
+      Bottom_GigE: 2,
+      Front_GigE: 1,
+    });
+    startStopCameraCall(request);
+  };
 
-    let handlePitchAxisClicked = () => {
-        const request = new ROSLIB.ServiceRequest({
-            X:- 1,
-            Y: -1,
-            Z: -1,
-            PITCH: 1,
-            ROLL: -1,
-            YAW: -1
-        });
-        toolbarServicesCall(request)
-    }
+  let handleStartBottomCameraClicked = () => {
+    const request = new ROSLIB.ServiceRequest({
+      Bottom_GigE: 1,
+      Front_GigE: 2,
+    });
+    startStopCameraCall(request);
+  };
 
-    let handleStartFrontCameraClicked = () => {
-        const request = new ROSLIB.ServiceRequest({
-            Bottom_GigE: 2,
-            Front_GigE: 1
-        })
-        startStopCameraCall(request)
-    }
+  return (
+    <AppBar position="static" style={{ background: '#2E3B55' }}>
+      <Toolbar>
+        <IconButton edge="start" color="inherit" aria-label="menu">
+          <MenuModule />
+        </IconButton>
+        <Button label="All" handler={handleAllAxisClicked} />
+        <Button
+          label="XY"
+          style={{ margin: '15px' }}
+          handler={handleXYAxisClicked}
+        />
+        <Button
+          label="Depth"
+          style={{ margin: '15px' }}
+          handler={handleDepthAxisClicked}
+        />
+        <Button
+          label="Roll"
+          style={{ margin: '15px' }}
+          handler={handleRollAxisClicked}
+        />
+        <Button
+          label="Pitch"
+          style={{ margin: '15px' }}
+          handler={handlePitchAxisClicked}
+        />
+        <Button
+          label="Yaw"
+          style={{ margin: '15px' }}
+          handler={handleYawAxisClicked}
+        />
+        <Button
+          label="Start front"
+          style={{ margin: '15px', backgroundColor: 'black', color: 'red' }}
+          handler={handleStartFrontCameraClicked}
+        />
+        <Button
+          label="Start bottom"
+          style={{ margin: '15px', backgroundColor: 'black', color: 'red' }}
+          handler={handleStartBottomCameraClicked}
+        />
+        <LabelAndValueModule label="AUV7" value={AUV7Temp} unit="C" />
+        <LabelAndValueModule label="AUV8" value={AUV8Temp} unit="C" />
+        <BatterieLevelIndicator
+          value={batteryLevel1}
+          label="Batterie 1"
+          unit="V"
+        />
+        <BatterieLevelIndicator
+          value={batteryLevel2}
+          label="Batterie 2"
+          unit="V"
+        />
+        <div style={{ marginLeft: 'auto' }}>
+          <Button
+            handler={() => {}}
+            disabled={true}
+            style={{
+              margin: '15px',
+              backgroundColor: isMissionSwitchOn ? 'green' : 'red',
+              color: 'white',
+            }}
+            label={
+              isMissionSwitchOn ? 'Mission switch on' : 'Mission switch off'
+            }
+          />
+          <Button
+            style={{
+              margin: '15px',
+              backgroundColor: isKillSwitchOn ? 'green' : 'red',
+              color: 'white',
+            }}
+            label={isKillSwitchOn ? 'Kill switch activated' : 'Kill switch off'}
+            handler={() => {}}
+            disabled={true}
+          />
+        </div>
+      </Toolbar>
+    </AppBar>
+  );
+};
 
-    let handleStartBottomCameraClicked = () => {
-        const request = new ROSLIB.ServiceRequest({
-            Bottom_GigE: 1,
-            Front_GigE: 2
-        })
-        startStopCameraCall(request)
-    }
-
-    return (
-        <AppBar position="static" style={{ background: '#2E3B55' }}>
-            <Toolbar>
-                <IconButton edge="start" color="inherit" aria-label="menu">
-                    <MenuModule />
-                </IconButton>
-                <Button variant="contained" onClick={handleAllAxisClicked}>
-                    All
-                </Button>
-                <Button variant="contained" style={{margin: '15px'}} onClick={handleXYAxisClicked}>
-                   XY
-                </Button>
-                <Button variant="contained" style={{margin: '15px'}} onClick={handleDepthAxisClicked}>
-                    Depth
-                </Button>
-                <Button variant="contained" style={{margin: '15px'}} onClick={handleRollAxisClicked}>
-                    Roll
-                </Button>
-                <Button variant="contained" style={{margin: '15px'}} onClick={handlePitchAxisClicked}>
-                    Pitch
-                </Button>
-                <Button variant="contained" style={{margin: '15px'}} onClick={handleYawAxisClicked}>
-                    Yaw
-                </Button>
-
-                <Button color="secondary"
-                        style={{margin: '15px', backgroundColor:'black', color:'red'}}
-                        onClick={handleStartFrontCameraClicked}>
-                    Start front
-                </Button>
-
-                <Button color="secondary"
-                        style={{margin: '15px', backgroundColor:'black', color:'red'}}
-                        onClick={handleStartBottomCameraClicked}>
-                    Start bottom
-                </Button>
-                <LabelAndValueModule
-                    label='AUV7'
-                    value={AUV7Temp}
-                    unit='C'/>
-                <LabelAndValueModule
-                    label='AUV8'
-                    value={AUV8Temp}
-                    unit='C'/>
-                <BatterieLevelIndicator
-                    value={batteryLevel1}
-                    label='Batterie 1'
-                    unit='V'
-                />
-                <BatterieLevelIndicator
-                    value={batteryLevel2}
-                    label='Batterie 2'
-                    unit='V'
-                />
-                <div style={{marginLeft: "auto"}}>
-                    <Button variant="contained"
-                            color="secondary"
-                            className="right"
-                            style={{margin: '15px', backgroundColor: isMissionSwitchOn ? 'green' : 'red', color:'white'}}
-                            disabled>
-                        {isMissionSwitchOn ? 'Mission switch activated' : 'Mission switch off'}
-                    </Button>
-
-                    <Button variant="contained"
-                            color="secondary"
-                            style={{margin: '15px', backgroundColor: isKillSwitchOn? 'green' : 'red', color:'white'}}
-                            disabled>
-                        {isKillSwitchOn ? 'Kill switch activated' : 'Kill switch off'}
-                    </Button>
-
-                </div>
-
-            </Toolbar>
-        </AppBar>
-    )
-}
-
-export default ToolbarModule
+export default ToolbarModule;

--- a/src/src/components/VisionUiExecution.tsx
+++ b/src/src/components/VisionUiExecution.tsx
@@ -5,7 +5,7 @@ import Select from '@material-ui/core/Select';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
-import { Button } from '@material-ui/core';
+import Button from './common/button/Button'
 import { useROSService } from '../hooks/useROSService'
 import ROSLIB from "roslib";
 import CachedIcon from '@material-ui/icons/Cached';
@@ -37,14 +37,6 @@ const useStyles = makeStyles((theme) => ({
         }
     },
 }));
-
-const ButtonStyle = withStyles({
-    contained: {
-        backgroundColor: 'lightgrey',
-        border: '2px solid rgba(0, 0, 0, 1.0)'
-    },
-
-})(Button);
 
 const VisionUIExecutionTabModule = () => {
 
@@ -201,11 +193,9 @@ const VisionUIExecutionTabModule = () => {
                 </Select>
             </FormControl>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<CachedIcon />}
-                onClick={handleRefreshFilterChainList}
+                label={<CachedIcon />}
+                handler={handleRefreshFilterChainList}
             ></Button>
             <br></br>
             <FormControl variant="filled" className={classes.formControl}>
@@ -224,20 +214,19 @@ const VisionUIExecutionTabModule = () => {
                 </Select>
             </FormControl>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<CachedIcon />}
-                onClick={handleRefreshMediaList}
-            ></Button>
+                label={<CachedIcon />}
+                handler={handleRefreshMediaList}
+            />
             <br></br>
             <div style={{ width: '75%', float: 'left' }} >
                 <TextField disabled={true} value={file} id="file_id" label="File" variant="outlined" fullWidth={true} style={{ padding: '10px 10px', marginTop: '10px' }} />
             </div>
             <input type='file' id='file' ref={inputFile} onChange={fileDialogClicked} style={{ display: 'none' }} />
-            <div style={{ float: 'right' }}><ButtonStyle variant='contained' style={{ fontSize: '20px', marginTop: '22px' }} onClick={handleFileOpen}>...</ButtonStyle></div>
+            <div style={{ float: 'right' }}><Button  style={{ fontSize: '20px', marginTop: '22px' }} handler={handleFileOpen} label="..." />
             <TextField value={topicName} onChange={handleTopicNameChange} id="visionUi_topicname_id" label="Topic Name" variant="outlined" fullWidth={true} style={{ padding: '10px 10px', marginTop: '10px' }} />
-            <ButtonStyle variant='contained' style={{ fontSize: '15px', marginTop: '10px', float: 'right' }} onClick={handleCreate}>create</ButtonStyle>
+            <Button style={{ fontSize: '15px', marginTop: '10px', float: 'right' }} handler={handleCreate} label="Create" />
+            </div>
         </div>
     );
 };

--- a/src/src/components/VisionUiFilter.tsx
+++ b/src/src/components/VisionUiFilter.tsx
@@ -5,7 +5,7 @@ import Select from '@material-ui/core/Select';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
-import { Button } from '@material-ui/core';
+import Button from './common/button/Button'
 import ListItemText from '@material-ui/core/ListItemText';
 import List from '@material-ui/core/List';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
@@ -617,18 +617,14 @@ const VisionUIFilterModule = () => {
                 </Select>
             </FormControl>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<CachedIcon />}
-                onClick={handleRefreshExecutionList}
+                label={<CachedIcon />}
+                handler={handleRefreshExecutionList}
             ></Button>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<DeleteIcon />}
-                onClick={handleClickDeleteExecution}
+                label={<DeleteIcon />}
+                handler={handleClickDeleteExecution}
             ></Button>
             <br></br>
             <FormControl variant="filled" className={classes.formControl}>
@@ -647,55 +643,41 @@ const VisionUIFilterModule = () => {
                 </Select>
             </FormControl>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<CachedIcon />}
-                onClick={handleRefreshFilterList}
+                label={<CachedIcon />}
+                handler={handleRefreshFilterList}
             ></Button>
             <br></br>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<AddCircleOutlineIcon />}
-                onClick={handleClickAdd}
+                label={<AddCircleOutlineIcon />}
+                handler={handleClickAdd}
             ></Button>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<ArrowDropUpIcon />}
-                onClick={handleClickUp}
+                label={<ArrowDropUpIcon />}
+                handler={handleClickUp}
             ></Button>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<ArrowDropDownIcon />}
-                onClick={handleClickDown}
+                label={<ArrowDropDownIcon />}
+                handler={handleClickDown}
             ></Button>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<DeleteIcon />}
-                onClick={handleClickDelete}
+                label={<DeleteIcon />}
+                handler={handleClickDelete}
             ></Button>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<SaveIcon />}
-                onClick={handleClickSave}
+                label={<SaveIcon />}
+                handler={handleClickSave}
             ></Button>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<RestoreIcon />}
-                onClick={handleClickRestore}
-            ></Button><br></br>
+                label={<RestoreIcon />}
+                handler={handleClickRestore}
+            />
             <ListFilterStyle><FilterList className={classes.root} /></ListFilterStyle><br></br>
             <ListSettingsStyle><SettingsList className={classes.root} /></ListSettingsStyle>
         </div>

--- a/src/src/components/VisionUiFilterChain.tsx
+++ b/src/src/components/VisionUiFilterChain.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { makeStyles, withStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
-import { Button } from '@material-ui/core';
+import Button from './common/button/Button'
 import ListItemText from '@material-ui/core/ListItemText';
 import List from '@material-ui/core/List';
 import { useROSService } from '../hooks/useROSService'
@@ -36,14 +36,6 @@ const useStyles = makeStyles((theme) => ({
         }
     },
 }));
-
-const ButtonStyle = withStyles({
-    contained: {
-        backgroundColor: 'lightgrey',
-        border: '2px solid rgba(0, 0, 0, 1.0)'
-    },
-
-})(Button);
 
 const VisionUIExecutionModule = () => {
 
@@ -185,17 +177,15 @@ const VisionUIExecutionModule = () => {
     return (
         <div>
             <TextField value={filterChainName} autoFocus={fieldHasFocus} onChange={handleFilterChainNameChange} id="visionUi_filterChainName_id" label="Name" variant="outlined" fullWidth={true} style={{ padding: '10px 10px' }}/>
-            <ButtonStyle variant='contained' style={{ fontSize: '15px', marginTop: '10px', float: 'left', marginLeft: '10px' }} onClick={handleAddFilterChain}>Add</ButtonStyle>
-            <ButtonStyle variant='contained' style={{ fontSize: '15px', marginTop: '10px', float: 'left', marginLeft: '10px' }} onClick={handleCloneFilterChain}>Clone</ButtonStyle>
-            <ButtonStyle variant='contained' style={{ fontSize: '15px', marginTop: '10px', float: 'left', marginLeft: '10px' }} onClick={handleDeleteFilterChain}>Delete</ButtonStyle><br></br>
+            <Button style={{ fontSize: '15px', marginTop: '10px', float: 'left', marginLeft: '10px' }} handler={handleAddFilterChain} label="Add" />
+            <Button style={{ fontSize: '15px', marginTop: '10px', float: 'left', marginLeft: '10px' }} handler={handleCloneFilterChain} label="Clone" />
+            <Button style={{ fontSize: '15px', marginTop: '10px', float: 'left', marginLeft: '10px' }} handler={handleDeleteFilterChain} label="Delete" /><br></br>
             <Button
-                variant="contained"
-                color="default"
                 className={classes.button}
-                startIcon={<CachedIcon />}
-                onClick={handleRefreshFilterChainList}
+                label={<CachedIcon />}
+                handler={handleRefreshFilterChainList}
                 style={{ marginTop: '14px' }}
-            ></Button>
+            />
             <ListFilterChainStyle><FilterChainList className={classes.root} /></ListFilterChainStyle>
         </div>
 

--- a/src/src/components/Waypoints.tsx
+++ b/src/src/components/Waypoints.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useState } from 'react';
 import Switch from './common/switch/Switch';
 import { GeneralContext } from "../context/generalContext";
-import { Button } from '@material-ui/core';
+import Button from './common/button/Button';
 import TextField from '@material-ui/core/TextField';
 import { withStyles } from '@material-ui/core/styles';
 import { useROSService } from '../hooks/useROSService'
@@ -9,14 +9,6 @@ import ROSLIB from "roslib";
 import { useROSTopicSubscriber } from "../hooks/useROSTopicSubscriber";
 
 const Waypoints = () => {
-
-    const ButtonStyle = withStyles({
-        contained: {
-            backgroundColor: 'lightgrey',
-            border: '2px solid rgba(0, 0, 0, 1.0)'
-        },
-
-    })(Button);
 
     //////////////////////////////////////
     // CONTROL MODE
@@ -353,9 +345,9 @@ const Waypoints = () => {
             {context => context && (
                 <div style={{ width: '100%', height: '100%', flexDirection: 'row', textAlign: 'center' }}>
                     <h1 style={{ fontSize: '20px', textAlign: 'center' }}>Waypoints</h1>
-                    <ButtonStyle variant='contained' style={{ width: '150px', marginBottom: '10px', fontSize: '10px', alignSelf: 'center' }} onClick={handleClearWayPoint}>Clear Waypoint</ButtonStyle>
-                    <ButtonStyle variant='contained' style={{ marginLeft: '10px', marginBottom: '10px', width: '150px', fontSize: '10px', alignSelf: 'center' }} onClick={handleSetInitialPosition}>Set initial Position</ButtonStyle>
-                    <ButtonStyle variant='contained' style={{ marginLeft: '10px', marginBottom: '10px', width: '150px', fontSize: '10px', alignSelf: 'center' }} onClick={handleSetDepthOffset}>Set depth Offset</ButtonStyle>
+                    <Button style={{ width: '150px', marginBottom: '10px', fontSize: '10px', alignSelf: 'center' }} handler={handleClearWayPoint} label="Clear Waypoint" />
+                    <Button style={{ marginLeft: '10px', marginBottom: '10px', width: '150px', fontSize: '10px', alignSelf: 'center' }} handler={handleSetInitialPosition} label="Set initial position" />
+                    <Button style={{ marginLeft: '10px', marginBottom: '10px', width: '150px', fontSize: '10px', alignSelf: 'center' }} handler={handleSetDepthOffset} label="Set depth offset" />
                     <Switch onLabel="Velocity"
                         offLabel="Position"
                         vertical={false}

--- a/src/src/components/common/button/Button.test.tsx
+++ b/src/src/components/common/button/Button.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import Button from './Button';
+
+describe('The Button component 🔘', () => {
+  it('has a default label', () => {
+    render(<Button handler={() => {}} />);
+
+    const defaultLabel = screen.getByText(/Submit/i);
+
+    expect(defaultLabel).toBeInTheDocument();
+  });
+
+  it('can be passed a label', () => {
+    render(<Button label="Act!" handler={() => {}} />);
+
+    const customLabel = screen.getByText(/Act!/i);
+
+    expect(customLabel).toBeInTheDocument();
+  });
+
+  it('dispatches actions on click', () => {
+    const onClick = jest.fn();
+
+    render(<Button handler={onClick} />);
+
+    const button = screen.getByTestId('test-button') as HTMLButtonElement;
+
+    fireEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('can be passed overriding styles (taking precedence over default style)', () => {
+    render(
+      <Button
+        style={{
+          backgroundColor: 'red',
+        }}
+        handler={() => {}}
+      />
+    );
+
+    const button = screen.getByTestId('test-button') as HTMLButtonElement;
+    expect(button.style.backgroundColor).toBe('red');
+  });
+
+  it('still applies its base styles even though we pass a style prop', () => {
+    render(<Button style={{ backgroundColor: 'green' }} handler={() => {}} />);
+
+    const button = screen.getByTestId('test-button') as HTMLButtonElement;
+
+    expect(button.style.border).toBe('1px solid blue');
+  });
+});

--- a/src/src/components/common/button/Button.test.tsx
+++ b/src/src/components/common/button/Button.test.tsx
@@ -79,4 +79,10 @@ describe('The Button component 🔘', () => {
 
     expect(button.disabled).toBe(false);
   });
+
+  it('can be passed a classname', () => {
+    render(<Button  className="something" handler={() => {}} />)
+    const button = screen.getByTestId('test-button') as HTMLButtonElement
+    expect(button.classList).toContain("something")
+  })
 });

--- a/src/src/components/common/button/Button.test.tsx
+++ b/src/src/components/common/button/Button.test.tsx
@@ -34,6 +34,13 @@ describe('The Button component 🔘', () => {
     expect(onClick).toHaveBeenCalledTimes(2);
   });
 
+  it('has a default "Button" CSS class', () => {
+    render(<Button style={{ backgroundColor: 'green' }} handler={() => {}} />);
+
+    const button = screen.getByTestId('test-button') as HTMLButtonElement;
+    expect(button).toHaveClass('Button');
+  });
+
   it('can be passed overriding styles (taking precedence over default style)', () => {
     render(
       <Button
@@ -47,12 +54,5 @@ describe('The Button component 🔘', () => {
     const button = screen.getByTestId('test-button') as HTMLButtonElement;
     expect(button.style.backgroundColor).toBe('red');
   });
-
-  it('still applies its base styles even though we pass a style prop', () => {
-    render(<Button style={{ backgroundColor: 'green' }} handler={() => {}} />);
-
-    const button = screen.getByTestId('test-button') as HTMLButtonElement;
-
-    expect(button.style.border).toBe('1px solid blue');
-  });
+  it.skip('CHECK some expected computed CSS of the component here (for example, we expect the border to be this way, etc.', () => {});
 });

--- a/src/src/components/common/button/Button.test.tsx
+++ b/src/src/components/common/button/Button.test.tsx
@@ -55,4 +55,14 @@ describe('The Button component 🔘', () => {
 
     expect(button.style.border).toBe('1px solid blue');
   });
+  it('can be disabled in the props', () => {
+    render(<Button disabled handler={() => {}} />);
+    const button = screen.getByTestId('test-button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+  it('can be enabled in the props', () => {
+    render(<Button disabled={false} handler={() => {}} />);
+    const button = screen.getByTestId('test-button') as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+  });
 });

--- a/src/src/components/common/button/Button.test.tsx
+++ b/src/src/components/common/button/Button.test.tsx
@@ -10,7 +10,7 @@ describe('The Button component 🔘', () => {
     expect(defaultLabel).toBeInTheDocument();
   });
 
-  it('can be passed a label', () => {
+  it('can be passed a string as a label', () => {
     render(<Button label="Act!" handler={() => {}} />);
 
     const customLabel = screen.getByText(/Act!/i);
@@ -18,7 +18,15 @@ describe('The Button component 🔘', () => {
     expect(customLabel).toBeInTheDocument();
   });
 
-  it('dispatches actions on click', () => {
+  it('can be passed a React element as a label', () => {
+    const element = <span>Hello!</span>;
+    render(<Button label={element} handler={() => {}} />);
+    const customElementLabel = screen.getByText(/Hello!/i);
+
+    expect(customElementLabel).toBeInTheDocument();
+  });
+
+  it('dispatches actions on click 📞', () => {
     const onClick = jest.fn();
 
     render(<Button handler={onClick} />);
@@ -45,6 +53,7 @@ describe('The Button component 🔘', () => {
     );
 
     const button = screen.getByTestId('test-button') as HTMLButtonElement;
+
     expect(button.style.backgroundColor).toBe('red');
   });
 
@@ -55,14 +64,19 @@ describe('The Button component 🔘', () => {
 
     expect(button.style.border).toBe('1px solid blue');
   });
+
   it('can be disabled in the props', () => {
     render(<Button disabled handler={() => {}} />);
+
     const button = screen.getByTestId('test-button') as HTMLButtonElement;
+
     expect(button.disabled).toBe(true);
   });
+
   it('can be enabled in the props', () => {
     render(<Button disabled={false} handler={() => {}} />);
     const button = screen.getByTestId('test-button') as HTMLButtonElement;
+
     expect(button.disabled).toBe(false);
   });
 });

--- a/src/src/components/common/button/Button.test.tsx
+++ b/src/src/components/common/button/Button.test.tsx
@@ -34,13 +34,6 @@ describe('The Button component 🔘', () => {
     expect(onClick).toHaveBeenCalledTimes(2);
   });
 
-  it('has a default "Button" CSS class', () => {
-    render(<Button style={{ backgroundColor: 'green' }} handler={() => {}} />);
-
-    const button = screen.getByTestId('test-button') as HTMLButtonElement;
-    expect(button).toHaveClass('Button');
-  });
-
   it('can be passed overriding styles (taking precedence over default style)', () => {
     render(
       <Button
@@ -54,5 +47,12 @@ describe('The Button component 🔘', () => {
     const button = screen.getByTestId('test-button') as HTMLButtonElement;
     expect(button.style.backgroundColor).toBe('red');
   });
-  it.skip('CHECK some expected computed CSS of the component here (for example, we expect the border to be this way, etc.', () => {});
+
+  it('still applies its base styles even though we pass a style prop', () => {
+    render(<Button style={{ backgroundColor: 'green' }} handler={() => {}} />);
+
+    const button = screen.getByTestId('test-button') as HTMLButtonElement;
+
+    expect(button.style.border).toBe('1px solid blue');
+  });
 });

--- a/src/src/components/common/button/Button.tsx
+++ b/src/src/components/common/button/Button.tsx
@@ -1,5 +1,4 @@
 import { FunctionComponent } from 'react';
-import style from './Button.module.css';
 
 type ButtonProps = {
   label?: string;
@@ -7,10 +6,17 @@ type ButtonProps = {
   style?: React.CSSProperties;
 };
 
+const DEFAULT_BUTTON_STYLE = {
+  backgroundColor: 'white',
+  border: '1px solid blue',
+};
+
 const Button: FunctionComponent<ButtonProps> = (props) => (
   <button
-    style={props.style}
-    className={style.Button}
+    style={{
+      ...DEFAULT_BUTTON_STYLE,
+      ...props.style,
+    }}
     data-testid="test-button"
     onClick={props.handler}
   >

--- a/src/src/components/common/button/Button.tsx
+++ b/src/src/components/common/button/Button.tsx
@@ -1,4 +1,6 @@
 import { FunctionComponent } from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import { Button as MUIButton } from '@material-ui/core';
 
 type ButtonProps = {
   label?: string;
@@ -11,8 +13,16 @@ const DEFAULT_BUTTON_STYLE = {
   border: '1px solid blue',
 };
 
+const GenericButton = withStyles({
+  contained: {
+    backgroundColor: 'lightgrey',
+    border: '2px solid black',
+  },
+})(MUIButton);
+
 const Button: FunctionComponent<ButtonProps> = (props) => (
-  <button
+  <GenericButton
+    variant="contained"
     style={{
       ...DEFAULT_BUTTON_STYLE,
       ...props.style,
@@ -21,7 +31,7 @@ const Button: FunctionComponent<ButtonProps> = (props) => (
     onClick={props.handler}
   >
     {props.label}
-  </button>
+  </GenericButton>
 );
 
 Button.defaultProps = {

--- a/src/src/components/common/button/Button.tsx
+++ b/src/src/components/common/button/Button.tsx
@@ -1,4 +1,5 @@
 import { FunctionComponent } from 'react';
+import style from './Button.module.css';
 
 type ButtonProps = {
   label?: string;
@@ -6,17 +7,10 @@ type ButtonProps = {
   style?: React.CSSProperties;
 };
 
-const DEFAULT_BUTTON_STYLE = {
-  backgroundColor: 'white',
-  border: '1px solid blue',
-};
-
 const Button: FunctionComponent<ButtonProps> = (props) => (
   <button
-    style={{
-      ...DEFAULT_BUTTON_STYLE,
-      ...props.style,
-    }}
+    style={props.style}
+    className={style.Button}
     data-testid="test-button"
     onClick={props.handler}
   >

--- a/src/src/components/common/button/Button.tsx
+++ b/src/src/components/common/button/Button.tsx
@@ -6,6 +6,7 @@ type ButtonProps = {
   label?: string;
   handler: () => void;
   style?: React.CSSProperties;
+  disabled?: boolean;
 };
 
 const DEFAULT_BUTTON_STYLE = {
@@ -29,6 +30,7 @@ const Button: FunctionComponent<ButtonProps> = (props) => (
     }}
     data-testid="test-button"
     onClick={props.handler}
+    disabled={props.disabled}
   >
     {props.label}
   </GenericButton>
@@ -37,6 +39,7 @@ const Button: FunctionComponent<ButtonProps> = (props) => (
 Button.defaultProps = {
   label: 'Submit',
   style: {},
+  disabled: false,
 };
 
 export default Button;

--- a/src/src/components/common/button/Button.tsx
+++ b/src/src/components/common/button/Button.tsx
@@ -3,7 +3,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { Button as MUIButton } from '@material-ui/core';
 
 type ButtonProps = {
-  label?: string;
+  label?: string | React.ReactNode;
   handler: () => void;
   style?: React.CSSProperties;
   disabled?: boolean;

--- a/src/src/components/common/button/Button.tsx
+++ b/src/src/components/common/button/Button.tsx
@@ -7,6 +7,7 @@ type ButtonProps = {
   handler: (event: React.MouseEvent<HTMLButtonElement>) => void;
   style?: React.CSSProperties;
   disabled?: boolean;
+  className?: string
 };
 
 const DEFAULT_BUTTON_STYLE = {
@@ -24,6 +25,7 @@ const GenericButton = withStyles({
 const Button: FunctionComponent<ButtonProps> = (props) => (
   <GenericButton
     variant="contained"
+    className={props.className}
     style={{
       ...DEFAULT_BUTTON_STYLE,
       ...props.style,

--- a/src/src/components/common/button/Button.tsx
+++ b/src/src/components/common/button/Button.tsx
@@ -1,0 +1,32 @@
+import { FunctionComponent } from 'react';
+
+type ButtonProps = {
+  label?: string;
+  handler: () => void;
+  style?: React.CSSProperties;
+};
+
+const DEFAULT_BUTTON_STYLE = {
+  backgroundColor: 'white',
+  border: '1px solid blue',
+};
+
+const Button: FunctionComponent<ButtonProps> = (props) => (
+  <button
+    style={{
+      ...DEFAULT_BUTTON_STYLE,
+      ...props.style,
+    }}
+    data-testid="test-button"
+    onClick={props.handler}
+  >
+    {props.label}
+  </button>
+);
+
+Button.defaultProps = {
+  label: 'Submit',
+  style: {},
+};
+
+export default Button;

--- a/src/src/components/common/button/Button.tsx
+++ b/src/src/components/common/button/Button.tsx
@@ -1,10 +1,10 @@
-import { FunctionComponent } from 'react';
+import React, { FunctionComponent } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import { Button as MUIButton } from '@material-ui/core';
 
 type ButtonProps = {
   label?: string | React.ReactNode;
-  handler: () => void;
+  handler: (event: React.MouseEvent<HTMLButtonElement>) => void;
   style?: React.CSSProperties;
   disabled?: boolean;
 };


### PR DESCRIPTION
## TODOS

- [x] Create and implement the base button style and variants if necessary.

## Description

Creates a generic button component to be used in the project. This button can be stylized by the parent component (the React component rendering `<Button />` with:
- `className="something"`
- `style={border: '1px solid red'}`

The precedence rules of the styling are as follows

Base Button style (overriden by) `className=` (overriden by) `style=`
Meaning that if a rule in `style` is also defined in the CSS classname, the button will apply the rule of `style`.

## Fixes

Fixes the inconsistent appearance of the buttons in the app.
- Closes: #57 

## How has this been tested ?

- unit tests: `cd src && npm run test`

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings