### PR TITLE
Don't copy package-lock.json in Dockerfile

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -7,7 +7,6 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 # Copy the dependencies
 COPY package.json ./
-COPY package-lock.json ./
 
 # Install dependencies
 RUN npm install


### PR DESCRIPTION
## Description

Removes `package-lock.json` from the expected files to build the Docker image.

## Fixes

- Closes: #76 

## How has this been tested ?

```bash
cd src
docker build . -t octopus-ui:latest
docker run -it -p 3001:3000 octopus-ui:latest
# checked that the app was running successfully.
```

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings